### PR TITLE
Remove gtag set call

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,9 +16,11 @@ homepage: "https://www.switchgrowth.com"
 documentation: "https://docs.switchgrowth.com/boost"
 versions:
   # Latest version
+  - sha: 0bf97d9457010243071d7c8f823dd730c249c2bf
+    changeNotes: Removing GtagSet API Call.
+  # Older versions (not used)
   - sha: ad05d29fcd4649cf3760d6e08b67310c258da107
     changeNotes: Minor codefix for exclusion options
-# Older versions (not used)
   - sha: 5d8d343346596b9fc7e3f3269b0a044f8aac0be6
     changeNotes: Datalayer Permission Fix
   - sha: cab0159f229464c2191471ca05935c0d406fa399

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,9 +16,11 @@ homepage: "https://www.switchgrowth.com"
 documentation: "https://docs.switchgrowth.com/boost"
 versions:
   # Latest version
+  - sha: 678f36ebe058aa454b57eb7f4005dd437089de91
+    changeNotes: Fix template ID.
+  # Older versions (not used)
   - sha: 0bf97d9457010243071d7c8f823dd730c249c2bf
     changeNotes: Removing GtagSet API Call.
-  # Older versions (not used)
   - sha: ad05d29fcd4649cf3760d6e08b67310c258da107
     changeNotes: Minor codefix for exclusion options
   - sha: 5d8d343346596b9fc7e3f3269b0a044f8aac0be6

--- a/template.tpl
+++ b/template.tpl
@@ -10,19 +10,19 @@ ___INFO___
 
 {
   "type": "TAG",
-  "id": "cvt_5NGWV",
+  "id": "cvt_temp_public_id",
   "version": 1,
+  "securityGroups": [],
   "displayName": "Switch Boost",
   "brand": {
-    "id": "github.com_switchgrowth",
-    "displayName": "switchgrowth",
+    "id": "switch_boost",
+    "displayName": "Switch Boost Activation Template",
     "thumbnail": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACXCAYAAAD3XaJHAAAACXBIWXMAAAWJAAAFiQFtaJ36AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAARaSURBVHgB7d3LTRtRFIDhAw7seGTHAiyngyQVkDSQdJBHA0E0wKMCqABSAXRAssuSVIBlQGIVHC+RsHMuYSJAZjwOnplz7v0/yXIkZ8Hil8/4Hj9EAAAAAAAAAAAAAAAAAAAAAAAAEjIluKfZbH7RuzW9tfTW1tt+r9fb7SpBYYR1h0a1oXebQx467nQ6rwSFNQQ3lpaWWo1G4/CxhxcWFn6rH4JCpgU3Zmdnj0b8l1VBYYQl/0ZgK+//TE1NLQgKSz6sMAJl+HUVniD5sGZmZvYEE5d0WCsrKx91xK0KJi7ZsMII1Kg2BKVINiwdgZsy4oId/y/JsG5H4AdBaZILa1ExAsuXXFjz8/Mjz6zwdEmFdXtmtSYoXVJhFVjbYEKSCavI2gaTk0RYrG2ql0RYOgIPBJWKPqxwZqV3LwWVijos1jb1iTos1jb1iTYs1jb1ijIsRmD9ogxLXwWGj3C1BLWJLizWNjZEFxZrGxuiCou1jR3RhMXaxpZowmIE2hJFWLdf5NESmOE+LF4F2uQ+LNY2NrkOi7WNXW7DYm1jm9uwGIG2uQxreXl5lRFom8uwpqen+YYY49yFxdrGB1dhsbbxw1VYrG38cBMWaxtfXITFCPTHRVi3Z1aLAjfMh8XaxifTYbG28ct0WKxt/DIbFmsb38yGxdrGN5Nhsbbxz+oz1keBa1bDaglcsxpWW+Ca1bC+Clwz+5vQeuK+b+y4oat/z7EYMBgMfl5dXe1cXFy0xSjTPzYe1jl67PCu3+/XvifUqMLfYOm7TLvX19dvzs/PTcT+EL9iX1A4sNXIrb0frNvr9V50lRjDb0L7tjg3N/deDCIs53REt8QgwvLvRAwiLN9O9LrvuxhEWL5ttZUY9Ezgkp5lHZ2enpo9SOYZy6lGo/FZDCMsn8yOwAxh+XPS6XQ2xTjCckZfBb4VBwjLlx3rIzBDWH6EM6stcYKw/AgX7OaWzY8hLAd0H7ivF+yu3vxIWPadaFhuRmCGsOwzf2Y1DCsdw3Rtc2B5bZOHZyzDdG2zLk4Rll0uR2CGsGxysbbJQ1gGeVnb5CEse1yPwAxh2RLWNjsSAcIyRI8X1j2tbfIQlhFhbaNnVocSCcKyweXaJg9h2RDFBftdhFUzj+9cKIKw6tWNbQRmCKteu7GNwAxh1cf92iYPYdUkhrVNHsKqR3SvAh8irOpFPQIzhFWxfr9v+jsXJoWwKhTOrM7Ozr5JAgirOtGtbfIQVnWiv2C/i7AqEOvaJg9hle8ypRGYIazybac0AjOEVa5wZhXFW43HRVglin1tk4ewypPUq8CHCKscSaxt8hBWCXRt80kSR1iTt6drG5M/Q1Ilwpqs8IHTbQFhFTUYDEZ9kHSgt82UL9jv4hdWx9BsNn/p3fMhD4WowtomibfEFMEz1hj0WSuEMxjyUJsReB9hjSF8BF4Deh1+eUv+BnYZ/h0OQhmBAAAAAAAAAAAAAAAAAAAAAAAAACbrD87ZGJzFdja/AAAAAElFTkSuQmCC"
   },
   "description": "A template for installing Switch Boost.",
   "containerContexts": [
     "WEB"
-  ],
-  "securityGroups": []
+  ]
 }
 
 
@@ -84,7 +84,6 @@ ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 const injectScript = require('injectScript');
 const encodeUriComponent = require('encodeUriComponent');
 const log = require('logToConsole');
-const gtagSet = require('gtagSet');
 
 const pixelId = data.pixelCode;
 const pixelUrl = data.pixelUrl;
@@ -140,12 +139,10 @@ function embedScripts(onSuccess, onFail) {
 embedScripts(
   () => {
     log("Switch Boost embedded");
-    gtagSet({'sg_pixel_loaded': true});
     data.gtmOnSuccess();
   },
   () => {
     log("Switch Boost unable to initialize");
-    gtagSet({'sg_pixel_loaded': false});
     data.gtmOnFailure();
   }
 );
@@ -190,32 +187,6 @@ ___WEB_PERMISSIONS___
               {
                 "type": 1,
                 "string": "https://*.s10h.io/*"
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "clientAnnotations": {
-      "isEditedByUser": true
-    },
-    "isRequired": true
-  },
-  {
-    "instance": {
-      "key": {
-        "publicId": "write_data_layer",
-        "versionId": "1"
-      },
-      "param": [
-        {
-          "key": "keyPatterns",
-          "value": {
-            "type": 2,
-            "listItem": [
-              {
-                "type": 1,
-                "string": "sg_pixel_loaded"
               }
             ]
           }

--- a/template.tpl
+++ b/template.tpl
@@ -10,7 +10,7 @@ ___INFO___
 
 {
   "type": "TAG",
-  "id": "cvt_temp_public_id",
+  "id": "cvt_5NGWV",
   "version": 1,
   "securityGroups": [],
   "displayName": "Switch Boost",
@@ -103,7 +103,7 @@ function localFail(script) {
 function embedScripts(onSuccess, onFail) {
   const scriptsToEmbed = [];
   let options = "";
-  
+
   if (excludedIds.length > 0) {
     options += "&skipped-input-ids=" + excludedIds.toString();
   }


### PR DESCRIPTION
We are calling a window.datalayer.push call from inside the pixel now so it's more accurate timing-wise, therefore we can remove the call from this tag template.