### PR TITLE
[hotfix] Fix Options Encoding

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,6 +17,8 @@ documentation: "https://docs.switchgrowth.com/boost"
 versions:
   # Latest version first, other notes are not used and
   # are for reference only.
+  - sha: 67a879a0bd0b79ae0ce7bc5f6bc8698ad7c9ae7c
+    changeNotes: Fix options encoding causing issues with account ID
   - sha: 18519e2cce6d39f215bed7ab2586f37d859bbd87
     changeNotes: Add support for configurable session size limit
   - sha: b1a08bd62e67194f32b462422ff3636a8a57711a

--- a/template.tpl
+++ b/template.tpl
@@ -144,7 +144,7 @@ function embedScripts(onSuccess, onFail) {
   options += "&session-byte-limit=" + sessionLimit;
 
   const urlForPixel = pixelUrl ? pixelUrl : 'api.s10h.io';
-  scriptsToEmbed.push('https://' + urlForPixel + '/pixel.js?id='+ encodeUriComponent(pixelId + options));
+  scriptsToEmbed.push('https://' + urlForPixel + '/pixel.js?id=' + encodeUriComponent(pixelId) + options);
   log("Scripts to embed:", scriptsToEmbed);
 
   while(scriptsToEmbed.length) {


### PR DESCRIPTION
I was encoding both account ID and options, and getting a bad readback in the pixel: `"account_id":"TF1cQdOupKSJsHA5&auto=true&session-byte-limit=500`

This is because I was encoding the options, so they get smashed into the pixel ID - this update fixes that formatting issue.