### PR TITLE
Feature - Add Event Queue Draining Functionality

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -111,7 +111,6 @@ function installSwitchStub() {
   const stub = { __queue: queue };
   const methods = [
     "sendEvent",
-    "sendSignal",
     "sendTemplateEvent",
     "sendManualCapture",
     "setSecureCookieValues",
@@ -324,19 +323,16 @@ scenarios:
     // Capture whatever the template installs on window.Switch.
     let installedSwitch = null;
 
-    // Simulate "no existing window.Switch on the page" so the install path runs.
     mock('copyFromWindow', (key) => {
       if (key === 'Switch') return installedSwitch;
       return undefined;
     });
 
-    // Capture the stub the template installs.
     mock('setInWindow', (key, value) => {
       if (key === 'Switch') installedSwitch = value;
       return true;
     });
 
-    // Don't actually try to download pixel.js during the test.
     mock('injectScript', (url, onSuccess) => {
       onSuccess();
     });
@@ -351,10 +347,9 @@ scenarios:
     assertThat(installedSwitch).isDefined();
     assertThat(installedSwitch.__queue).isEqualTo([]);
 
-    // All 11 queueable methods are functions on the stub.
+    // All 10 queueable methods are functions on the stub.
     const expectedMethods = [
       'sendEvent',
-      'sendSignal',
       'sendTemplateEvent',
       'sendManualCapture',
       'setSecureCookieValues',
@@ -370,22 +365,22 @@ scenarios:
     });
 
     // Calling a stub method pushes a [methodName, args] tuple onto __queue.
-    installedSwitch.sendSignal('pipeline-A', { customer: { email: 'x' } });
+    installedSwitch.sendEvent('api-key', 'pipeline-A', { customer: { email: 'x' } });
     installedSwitch.sendTemplateEvent({ apiKey: 'k', pipelineId: 'p' });
     installedSwitch.transactionId();
 
     assertThat(installedSwitch.__queue.length).isEqualTo(3);
-    assertThat(installedSwitch.__queue[0][0]).isEqualTo('sendSignal');
-    assertThat(installedSwitch.__queue[0][1][0]).isEqualTo('pipeline-A');
+    assertThat(installedSwitch.__queue[0][0]).isEqualTo('sendEvent');
+    assertThat(installedSwitch.__queue[0][1][0]).isEqualTo('api-key');
     assertThat(installedSwitch.__queue[1][0]).isEqualTo('sendTemplateEvent');
     assertThat(installedSwitch.__queue[2][0]).isEqualTo('transactionId');
 
-    // Tag still finishes successfully (gtmOnSuccess called via embedScripts onSuccess).
+    // Tag still finishes successfully.
     assertApi('gtmOnSuccess').wasCalled();
 - name: Queue Event Idempotency Test
   code: |
-    // First run — empty initial state.
     let installedSwitch = null;
+
     mock('copyFromWindow', (key) => key === 'Switch' ? installedSwitch : undefined);
     mock('setInWindow', (key, value) => {
       if (key === 'Switch') installedSwitch = value;
@@ -393,20 +388,22 @@ scenarios:
     });
     mock('injectScript', (url, onSuccess) => onSuccess());
 
+    // First Boost run installs the stub.
     runCode({ pixelCode: "test_pixel_id" });
 
-    // Add something to the queue from a "Realtime Event tag fire" between Boost runs.
-    installedSwitch.sendSignal('pipeline-A', { foo: 'bar' });
+    // Realtime Event tag fires between Boost runs and queues a call.
+    installedSwitch.sendEvent('api-key', 'pipeline-A', { foo: 'bar' });
+
     const queueBefore = installedSwitch.__queue;
     const stubBefore = installedSwitch;
     assertThat(queueBefore.length).isEqualTo(1);
 
-    // Second Boost run — should NOT replace the stub or wipe the queue.
+    // Second Boost run must NOT replace the stub or wipe the queue.
     runCode({ pixelCode: "test_pixel_id" });
 
     assertThat(installedSwitch).isEqualTo(stubBefore);
     assertThat(installedSwitch.__queue.length).isEqualTo(1);
-    assertThat(installedSwitch.__queue[0][0]).isEqualTo('sendSignal');
+    assertThat(installedSwitch.__queue[0][0]).isEqualTo('sendEvent');
 
 
 ___NOTES___

--- a/template.tpl
+++ b/template.tpl
@@ -50,23 +50,6 @@ ___TEMPLATE_PARAMETERS___
     "valueHint": "pixel.clientwebsite.com (no https or slashes needed)"
   },
   {
-    "type": "CHECKBOX",
-    "name": "automaticMode",
-    "checkboxText": "Automatic Mode",
-    "simpleValueType": true,
-    "help": "Automatic mode will monitor the page and capture advertising identifiers automatically for submission.",
-    "defaultValue": true
-  },
-  {
-    "type": "TEXT",
-    "name": "sessionLimit",
-    "displayName": "Session Size Limit",
-    "simpleValueType": true,
-    "defaultValue": 4000,
-    "help": "The maximum bytes that a session size can be.",
-    "valueUnit": "bytes"
-  },
-  {
     "type": "TEXT",
     "name": "excludedIds",
     "displayName": "CSS Element IDs to exclude",
@@ -101,16 +84,53 @@ ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 const injectScript = require('injectScript');
 const encodeUriComponent = require('encodeUriComponent');
 const log = require('logToConsole');
-const makeInteger = require('makeInteger');
+const setInWindow = require('setInWindow');
+const copyFromWindow = require('copyFromWindow');
 
 const pixelId = data.pixelCode;
 const pixelUrl = data.pixelUrl;
-const automaticMode = data.automaticMode;
-const sessionLimit = data.sessionLimit;
 const excludedIds = data.excludedIds || "";
 const excludedInputTypes = data.excludedInputTypes || "";
 const excludedAttributes = data.excludedAttributes || "";
 const cacheKey = "switch-" + pixelId;
+
+// Pre-load event queue: install a stub on window.Switch BEFORE pixel.js loads,
+// so calls from Switch Real-Time Event tags (or any other Switch.* caller)
+// fired during the pixel.js download window are buffered and replayed when
+// pixel.js arrives.
+//
+// Keep this `methods` array in sync with QUEUEABLE_METHODS in
+// pixel/src/eventQueue.ts. Anything missing here will throw TypeError if
+// called pre-load.
+function installSwitchStub() {
+  const existing = copyFromWindow("Switch");
+  if (existing && existing.__sgReady) return;   // real Switch already loaded
+  if (existing && existing.__queue) return;     // stub already installed (idempotent)
+
+  const queue = [];
+  const stub = { __queue: queue };
+  const methods = [
+    "sendEvent",
+    "sendSignal",
+    "sendTemplateEvent",
+    "sendManualCapture",
+    "setSecureCookieValues",
+    "getSecureCookieValues",
+    "deleteSecureCookie",
+    "sha256",
+    "transactionId",
+    "getUserAgent",
+    "getIp"
+  ];
+  methods.forEach(function (m) {
+    stub[m] = function () {
+      const args = [];
+      for (let i = 0; i < arguments.length; i++) args.push(arguments[i]);
+      queue.push([m, args]);
+    };
+  });
+  setInWindow("Switch", stub, true);
+}
 
 function localSuccess(script) {
   log("Loaded:", script);
@@ -123,7 +143,7 @@ function localFail(script) {
 function embedScripts(onSuccess, onFail) {
   const scriptsToEmbed = [];
   let options = "";
-  
+
   if (excludedIds.length > 0) {
     options += "&skipped-input-ids=" + excludedIds.toString();
   }
@@ -135,16 +155,9 @@ function embedScripts(onSuccess, onFail) {
   if (excludedInputTypes.length > 0 ) {
     options += "&skipped-input-types=" + excludedInputTypes.toString();
   }
-  
-  let autoQuery = automaticMode ? "&auto=true" : "&auto=false";
-  
-  options += autoQuery;
-  
-  // Script handles flooring the value to 500 minimum
-  options += "&session-byte-limit=" + sessionLimit;
 
   const urlForPixel = pixelUrl ? pixelUrl : 'api.s10h.io';
-  scriptsToEmbed.push('https://' + urlForPixel + '/pixel.js?id=' + encodeUriComponent(pixelId) + options);
+  scriptsToEmbed.push('https://' + urlForPixel + '/pixel.js?id='+ encodeUriComponent(pixelId + options));
   log("Scripts to embed:", scriptsToEmbed);
 
   while(scriptsToEmbed.length) {
@@ -162,6 +175,9 @@ function embedScripts(onSuccess, onFail) {
     onFail();
   }
 }
+
+// Install the queue stub before kicking off pixel.js download.
+installSwitchStub();
 
 embedScripts(
   () => {
@@ -224,6 +240,67 @@ ___WEB_PERMISSIONS___
       "isEditedByUser": true
     },
     "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "access_globals",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "keys",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "Switch"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
   }
 ]
 
@@ -242,6 +319,94 @@ scenarios:
 
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
+- name: Queue Event Test
+  code: |
+    // Capture whatever the template installs on window.Switch.
+    let installedSwitch = null;
+
+    // Simulate "no existing window.Switch on the page" so the install path runs.
+    mock('copyFromWindow', (key) => {
+      if (key === 'Switch') return installedSwitch;
+      return undefined;
+    });
+
+    // Capture the stub the template installs.
+    mock('setInWindow', (key, value) => {
+      if (key === 'Switch') installedSwitch = value;
+      return true;
+    });
+
+    // Don't actually try to download pixel.js during the test.
+    mock('injectScript', (url, onSuccess) => {
+      onSuccess();
+    });
+
+    const mockData = {
+      pixelCode: "test_pixel_id"
+    };
+
+    runCode(mockData);
+
+    // Stub was installed with an empty queue.
+    assertThat(installedSwitch).isDefined();
+    assertThat(installedSwitch.__queue).isEqualTo([]);
+
+    // All 11 queueable methods are functions on the stub.
+    const expectedMethods = [
+      'sendEvent',
+      'sendSignal',
+      'sendTemplateEvent',
+      'sendManualCapture',
+      'setSecureCookieValues',
+      'getSecureCookieValues',
+      'deleteSecureCookie',
+      'sha256',
+      'transactionId',
+      'getUserAgent',
+      'getIp'
+    ];
+    expectedMethods.forEach((m) => {
+      assertThat(typeof installedSwitch[m]).isEqualTo('function');
+    });
+
+    // Calling a stub method pushes a [methodName, args] tuple onto __queue.
+    installedSwitch.sendSignal('pipeline-A', { customer: { email: 'x' } });
+    installedSwitch.sendTemplateEvent({ apiKey: 'k', pipelineId: 'p' });
+    installedSwitch.transactionId();
+
+    assertThat(installedSwitch.__queue.length).isEqualTo(3);
+    assertThat(installedSwitch.__queue[0][0]).isEqualTo('sendSignal');
+    assertThat(installedSwitch.__queue[0][1][0]).isEqualTo('pipeline-A');
+    assertThat(installedSwitch.__queue[1][0]).isEqualTo('sendTemplateEvent');
+    assertThat(installedSwitch.__queue[2][0]).isEqualTo('transactionId');
+
+    // Tag still finishes successfully (gtmOnSuccess called via embedScripts onSuccess).
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Queue Event Idempotency Test
+  code: |
+    // First run — empty initial state.
+    let installedSwitch = null;
+    mock('copyFromWindow', (key) => key === 'Switch' ? installedSwitch : undefined);
+    mock('setInWindow', (key, value) => {
+      if (key === 'Switch') installedSwitch = value;
+      return true;
+    });
+    mock('injectScript', (url, onSuccess) => onSuccess());
+
+    runCode({ pixelCode: "test_pixel_id" });
+
+    // Add something to the queue from a "Realtime Event tag fire" between Boost runs.
+    installedSwitch.sendSignal('pipeline-A', { foo: 'bar' });
+    const queueBefore = installedSwitch.__queue;
+    const stubBefore = installedSwitch;
+    assertThat(queueBefore.length).isEqualTo(1);
+
+    // Second Boost run — should NOT replace the stub or wipe the queue.
+    runCode({ pixelCode: "test_pixel_id" });
+
+    assertThat(installedSwitch).isEqualTo(stubBefore);
+    assertThat(installedSwitch.__queue.length).isEqualTo(1);
+    assertThat(installedSwitch.__queue[0][0]).isEqualTo('sendSignal');
 
 
 ___NOTES___

--- a/template.tpl
+++ b/template.tpl
@@ -92,6 +92,8 @@ const pixelUrl = data.pixelUrl;
 const excludedIds = data.excludedIds || "";
 const excludedInputTypes = data.excludedInputTypes || "";
 const excludedAttributes = data.excludedAttributes || "";
+const automaticMode = data.automaticMode;
+const sessionLimit = data.sessionLimit;
 const cacheKey = "switch-" + pixelId;
 
 // Pre-load event queue: install a stub on window.Switch BEFORE pixel.js loads,
@@ -154,6 +156,12 @@ function embedScripts(onSuccess, onFail) {
   if (excludedInputTypes.length > 0 ) {
     options += "&skipped-input-types=" + excludedInputTypes.toString();
   }
+
+  let autoQuery = automaticMode ? "&auto=true" : "&auto=false";
+  options += autoQuery;
+
+  // pixel.js floors the value to 500 minimum on the receiving side
+  options += "&session-byte-limit=" + sessionLimit;
 
   const urlForPixel = pixelUrl ? pixelUrl : 'api.s10h.io';
   scriptsToEmbed.push('https://' + urlForPixel + '/pixel.js?id='+ encodeUriComponent(pixelId + options));
@@ -378,7 +386,7 @@ scenarios:
     // Tag still finishes successfully.
     assertApi('gtmOnSuccess').wasCalled();
 - name: Queue Event Idempotency Test
-  code: |
+  code: |-
     let installedSwitch = null;
 
     mock('copyFromWindow', (key) => key === 'Switch' ? installedSwitch : undefined);


### PR DESCRIPTION
## Because

Switch API calls fired by other GTM tags (Switch Real-Time Event most commonly) regularly race ahead of `pixel.js` finishing its download. When the trigger event hits before `window.Switch` exists, the `callInWindow('Switch.sendTemplateEvent', …)` call is silently lost and the conversion never reaches the backend. The companion `pixel.js` change adds drain logic that replays a `window.Switch.__queue` once it's loaded — this PR adds the **producer half**: an inline stub on `window.Switch` that captures calls into that queue before `pixel.js` is even requested.

Switch Boost's Sandboxed JS runs synchronously inside GTM's tag evaluation step, so the stub lands on `window.Switch` *before* the script tag for `pixel.js` is even injected — bridging exactly the race window today's bug report describes.

This PR alone is a no-op without the companion `pixel.js` change. The two together close the bug.

## This PR

- Adds two new GTM Sandboxed APIs to the Switch Boost template requires: `setInWindow` and `copyFromWindow`.
- Adds an `installSwitchStub()` function that:
  - Reads `window.Switch` via `copyFromWindow`. Bails out if a real Switch is already loaded (`__sgReady === true`) or a stub is already installed (`__queue` exists) — fully idempotent.
  - Otherwise builds an object with an empty `__queue` array and one stub function per public Switch method (`sendEvent`, `sendTemplateEvent`, `sendManualCapture`, `setSecureCookieValues`, `getSecureCookieValues`, `deleteSecureCookie`, `sha256`, `transactionId`, `getUserAgent`, `getIp` — 11 total, mirroring `QUEUEABLE_METHODS` in the pixel.js companion PR).
  - Each stub function pushes `[methodName, args]` onto `__queue`.
  - Writes the stub to `window.Switch` via `setInWindow('Switch', stub, true)`.
- Calls `installSwitchStub()` immediately before the existing `embedScripts()` invocation, so the stub is in place before `injectScript` queues the `pixel.js` request.
- Adds a `Queue Event Test` test case that mocks `copyFromWindow`, `setInWindow`, and `injectScript`, runs the template, and asserts:
  - The stub was installed on `window.Switch` with an empty `__queue`.
  - All 11 expected methods are functions on the stub.
  - Calling stub methods pushes correctly-shaped `[name, args]` tuples onto `__queue` in FIFO order.
  - The tag still finishes successfully (`gtmOnSuccess` called).
- Updates the **Permissions** tab to grant `Accesses Global Variables` read + write + execute for key `Switch` (required by `setInWindow` / `copyFromWindow`).
- Bumps the template version.

## Reproduction Steps

1. In the Template Editor, open **Code** tab and click **Run Code** — should complete without permission errors.
2. Run the **Tests** tab — both existing `Has a Pixel ID` and the new `Queue Event Test` should pass.
3. Push the template to a staging GTM container.
4. On a staging client site, open devtools console *before* the page loads, then reload. Inspect `window.Switch` immediately:
   - **Before** `pixel.js` finishes loading: should be `{ __queue: [], sendEvent: fn, sendSignal: fn, … }` — the stub.
   - Call `window.Switch.__queue.length` should become `1`.
   - **After** `pixel.js` loads: `window.Switch instanceof Switch` becomes `true`, `__sgReady === true`, `__queue` is `undefined`. The queued `sendSignal` call has been replayed against the real backend (visible in the network tab as a `POST /api/private/signals`).
5. For a fully scripted demo, point a browser at the local pixel test page in the companion PR ([`pixel/test/queue_test.html`](https://github.com/.../switch-rails/blob/feature-boost-event-queue/pixel/test/queue_test.html)) — but **remove the inline stub install block from that page first**, so Switch Boost is the only thing installing the stub. Every Live Check should still go green.

## Additional Information / Pre or Post Deployment Tasks

**Companion pixel.js change:** https://github.com/switchgrowth/switch-rails/pull/2507

**This PR alone is a no-op without the companion pixel.js change.** The drain logic that turns the queue into real network calls lives in pixel.js. Both must ship for the bug to actually be fixed.

**Post-deploy rollout (per-client GTM container):**

1. Merge & publish this template version. The new template is now available in the Community Template Gallery / template library.
2. **For every client GTM container that has Switch Boost installed**, the template must be re-imported / republished individually — there is no automatic propagation between containers:
   - Open the client's GTM workspace → **Templates** → **Switch Boost** → update to the new template version → bump the container version → publish.
   - Audit which containers have Switch Boost installed and coordinate publishes across them. Containers that haven't been updated continue to lose pre-load conversions until they are.
3. After each client container is republished, verify on a real page load that `window.Switch.__queue` exists *before* `pixel.js` arrives (devtools console immediately on page load).

**Maintenance contract:** the `methods` array in this template must stay in sync with `QUEUEABLE_METHODS` in `pixel/src/eventQueue.ts` of the companion repo. Adding a new public method to `Switch` requires updating both — anything missing from this template's list will throw `TypeError` if called pre-load.
